### PR TITLE
Use CSPRNG function instead of mt_rand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,11 @@
         }
     },
     "require": {
-        "php": ">= 5.4"
+        "php": ">= 5.4",
+        "paragonie/random_compat": ">=2"
     },
     "require-dev": {
-    	"squizlabs/php_codesniffer": "1.*",
+        "squizlabs/php_codesniffer": "1.*",
         "phpunit/phpunit": "4.*",
         "satooshi/php-coveralls": "0.*"
     },

--- a/src/Cuid.php
+++ b/src/Cuid.php
@@ -123,10 +123,8 @@ class Cuid
     protected static function random($blockSize = Cuid::NORMAL_BLOCK)
     {
         // Get random integer
-        $modifier = pow(Cuid::BASE36, Cuid::NORMAL_BLOCK);
-        $random = mt_rand() / mt_getrandmax();
-
-        $random = $random * $modifier;
+        $max = pow(Cuid::BASE36, Cuid::NORMAL_BLOCK);
+        $random = random_int(0, $max);
 
         // Convert integer to hash
         $hash = Cuid::pad(


### PR DESCRIPTION
As noted in the PHP manual, the mt_rand functions are NOT cryptographically secure. I've included the random_compat library to add cryptographically secure random functions to PHP < 7.0, and then used random_int instead of mt_rand.