### PR TITLE
Fix random() for PHP 7.4

### DIFF
--- a/src/Cuid.php
+++ b/src/Cuid.php
@@ -131,7 +131,7 @@ class Cuid
         // Convert integer to hash
         $hash = Cuid::pad(
             base_convert(
-                $random,
+                floor($random),
                 Cuid::DECIMAL,
                 Cuid::BASE36
             ),


### PR DESCRIPTION
I've just updated to PHP 7.4 and found that when trying to create a cuid, I always get an error. I think this can be traced to changed behaviour of `base_convert`:

```
>>> base_convert(1, 10, 36) 
=> "1"
>>> base_convert(1.1, 10, 36)
PHP Deprecated:  Invalid characters passed for attempted conversion, these have been ignored in Psy Shell code on line 1
```

This change uses `floor()` to ensure only integers are passed to `base_convert`. This is already done in the `timestamp()` function.